### PR TITLE
Fix output file naming (input.1 -> input file basename)

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -35,7 +35,7 @@ Channel
     .fromPath(params.table_vcf_location)
     .ifEmpty { exit 1, "Cannot find input file : ${params.table_vcf_location}" }
     .splitCsv(skip:1)
-    .map {file_name, vcf_WGS, vcf_WGS_idx -> [ file_name, vcf_WGS, vcf_WGS_idx ] }
+    .map {file_name, vcf_WGS, vcf_WGS_idx -> [ file_name, file(vcf_WGS), file(vcf_WGS_idx) ] }
     .set { ch_input }
 
 // Define Channels from input


### PR DESCRIPTION
## Overview

This PR addressed the issue documented at #1, related to failure to capture the filename from the input vcf to be used for naming the output files.

## Purpose

To achieve that in the line below the 2 missing file method calls `file()` for the vcf and vcf index items.

https://github.com/lb83/subset_WES_AggV2/blob/7455329d11de2f75101c2675ff398a807f9b1e82/main.nf#L38


```diff
-  .map {file_name, vcf_WGS, vcf_WGS_idx -> [ file_name, vcf_WGS, vcf_WGS_idx ] } 
+  .map {file_name, vcf_WGS, vcf_WGS_idx -> [ file_name, file(vcf_WGS), file(vcf_WGS_idx) ] } 
```

## Changes

- Adds `file()` method calls in the relevant channel mapping
